### PR TITLE
Switching to fast qubit operator conversion

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
     install_requires=[
         'z-quantum-core',
         'qe-openfermion',
-        'forestopenfermion'
+        'forestopenfermion @ http://github.com/zapatacomputing/forest-openfermion/tarball/fast-op-conversion'
     ]
 )


### PR DESCRIPTION
This PR changes the setup.py to use the zapatacomputing fork of forest-openfermion and should be reverted once rigetti/forest-openfermion#19 is merged.

Note that this setup.py will not cause an existing forest-openfermion installation to be replaced; see pypa/pip#5780.