### PR TITLE
Derived tests as contracts

### DIFF
--- a/src/python/zquantum/qaoa/ansatzes/farhi2_test.py
+++ b/src/python/zquantum/qaoa/ansatzes/farhi2_test.py
@@ -1,4 +1,5 @@
 
+from copy import copy, deepcopy
 from zquantum.core.interfaces.ansatz_test import AnsatzTests
 from zquantum.core.circuit import Circuit, Gate, Qubit
 from zquantum.core.utils import compare_unitary
@@ -76,68 +77,76 @@ def _validate_get_executable_circuit_does_not_contain_symbols(ansatz):
     #     return len(gate.symbolic_params) == 0
     return all(len(gate.symbolic_params) == 0 for gate in circuit.gates)
 
-# ----------- start
 
-class TestFahriInherited:
-    @pytest.fixture
-    def ansatz(self):
-        """Plugs-in into AnsatzTests test cases."""
-        return _make_ansatz()
+ALL_CONTRACTS = [
+    _validate_setting_number_of_layers,
+    _validate_number_of_qubits_greater_than_0,
+]
 
-    def test_set_number_of_layers(self, ansatz):
-        assert _validate_setting_number_of_layers(ansatz)
 
-        # # Given
-        # new_number_of_layers = 100
-        # # When
-        # ansatz.number_of_layers = new_number_of_layers
-        # # Then
-        # assert ansatz.number_of_layers == new_number_of_layers
+# ^^^^ - z-quantum-core
+# below - z-quantum-qaoa
 
-    def test_set_number_of_layers_invalidates_parametrized_circuit(self, ansatz):
-        assert _validate_set_number_of_layers_invalidates_parametrized_circuit(ansatz)
-        # # Given
-        # new_number_of_layers = 100
-        # if ansatz.supports_parametrized_circuits:
-        #     initial_circuit = ansatz.parametrized_circuit
 
-        #     # When
-        #     ansatz.number_of_layers = new_number_of_layers
+@pytest.mark.parametrize('contract', ALL_CONTRACTS)
+def test_ansatz_contract(self, contract):
+    ansatz = _make_ansatz()
+    assert contract(ansatz)
 
-        #     # Then
-        #     assert ansatz._parametrized_circuit is None
+#     def test_set_number_of_layers(self, ansatz):
+#         assert _validate_setting_number_of_layers(ansatz)
 
-    # TODO: check with QCBM?
-    def test_number_of_params_greater_than_0(self, ansatz):
-        assert _validate_number_of_params_greater_than_0(ansatz)
-        # if ansatz.number_of_layers != 0:
-        #     assert ansatz.number_of_params >= 0
+#         # # Given
+#         # new_number_of_layers = 100
+#         # # When
+#         # ansatz.number_of_layers = new_number_of_layers
+#         # # Then
+#         # assert ansatz.number_of_layers == new_number_of_layers
 
-    def test_number_of_qubits_greater_than_0(self, ansatz):
-        assert _validate_number_of_qubits_greater_than_0(ansatz)
+#     def test_set_number_of_layers_invalidates_parametrized_circuit(self, ansatz):
+#         assert _validate_set_number_of_layers_invalidates_parametrized_circuit(ansatz)
+#         # # Given
+#         # new_number_of_layers = 100
+#         # if ansatz.supports_parametrized_circuits:
+#         #     initial_circuit = ansatz.parametrized_circuit
 
-    def test_get_executable_circuit_is_not_empty(self, ansatz):
-        assert _validate_get_executable_circuit_is_not_empty(ansatz)
-        # # Given
-        # params = np.random.random([ansatz.number_of_params])
+#         #     # When
+#         #     ansatz.number_of_layers = new_number_of_layers
 
-        # # When
-        # circuit = ansatz.get_executable_circuit(params)
+#         #     # Then
+#         #     assert ansatz._parametrized_circuit is None
 
-        # # Then
-        # assert len(circuit.gates) > 0
+#     # TODO: check with QCBM?
+#     def test_number_of_params_greater_than_0(self, ansatz):
+#         assert _validate_number_of_params_greater_than_0(ansatz)
+#         # if ansatz.number_of_layers != 0:
+#         #     assert ansatz.number_of_params >= 0
 
-    def test_get_executable_circuit_does_not_contain_symbols(self, ansatz):
-        assert _validate_get_executable_circuit_does_not_contain_symbols(ansatz)
-        # # Given
-        # params = np.random.random([ansatz.number_of_params])
+#     def test_number_of_qubits_greater_than_0(self, ansatz):
+#         assert _validate_number_of_qubits_greater_than_0(ansatz)
 
-        # # When
-        # circuit = ansatz.get_executable_circuit(params=params)
+#     def test_get_executable_circuit_is_not_empty(self, ansatz):
+#         assert _validate_get_executable_circuit_is_not_empty(ansatz)
+#         # # Given
+#         # params = np.random.random([ansatz.number_of_params])
 
-        # # Then
-        # for gate in circuit.gates:
-        #     assert len(gate.symbolic_params) == 0
+#         # # When
+#         # circuit = ansatz.get_executable_circuit(params)
+
+#         # # Then
+#         # assert len(circuit.gates) > 0
+
+#     def test_get_executable_circuit_does_not_contain_symbols(self, ansatz):
+#         assert _validate_get_executable_circuit_does_not_contain_symbols(ansatz)
+#         # # Given
+#         # params = np.random.random([ansatz.number_of_params])
+
+#         # # When
+#         # circuit = ansatz.get_executable_circuit(params=params)
+
+#         # # Then
+#         # for gate in circuit.gates:
+#         #     assert len(gate.symbolic_params) == 0
 
 
 class TestFahriStandalone:

--- a/src/python/zquantum/qaoa/ansatzes/farhi2_test.py
+++ b/src/python/zquantum/qaoa/ansatzes/farhi2_test.py
@@ -1,0 +1,162 @@
+
+from zquantum.core.interfaces.ansatz_test import AnsatzTests
+from zquantum.core.circuit import Circuit, Gate, Qubit
+from zquantum.core.utils import compare_unitary
+from zquantum.core.openfermion import change_operator_type
+from .farhi_ansatz import (
+    QAOAFarhiAnsatz,
+    create_farhi_qaoa_circuits,
+    create_all_x_mixer_hamiltonian,
+)
+from openfermion import QubitOperator, IsingOperator
+import pytest
+import numpy as np
+import sympy
+
+
+def _make_ansatz():
+    cost_hamiltonian = QubitOperator((0, "Z")) + QubitOperator((1, "Z"))
+    mixer_hamiltonian = QubitOperator((0, "X")) + QubitOperator((1, "X"))
+    return QAOAFarhiAnsatz(
+        number_of_layers=1,
+        cost_hamiltonian=cost_hamiltonian,
+        mixer_hamiltonian=mixer_hamiltonian,
+    )
+
+
+class TestFahriInherited(AnsatzTests):
+    @pytest.fixture
+    def ansatz(self):
+        """Plugs-in into AnsatzTests test cases."""
+        return _make_ansatz()
+
+
+class TestFahriStandalone:
+    @pytest.fixture
+    def ansatz(self):
+        return _make_ansatz()
+
+    @pytest.fixture
+    def beta(self):
+        return sympy.Symbol("beta_0")
+
+    @pytest.fixture
+    def gamma(self):
+        return sympy.Symbol("gamma_0")
+
+    @pytest.fixture
+    def symbols_map(self, beta, gamma):
+        beta_value = 0.5
+        gamma_value = 0.7
+        return [(beta, beta_value), (gamma, gamma_value)]
+
+    @pytest.fixture
+    def target_unitary(self, beta, gamma, symbols_map):
+        target_circuit = Circuit()
+        target_circuit.gates = []
+        target_circuit.gates.append(Gate("H", [Qubit(0)]))
+        target_circuit.gates.append(Gate("H", [Qubit(1)]))
+        target_circuit.gates.append(Gate("Rz", [Qubit(0)], [2.0 * gamma]))
+        target_circuit.gates.append(Gate("Rz", [Qubit(1)], [2.0 * gamma]))
+        target_circuit.gates.append(Gate("Rx", [Qubit(0)], [2.0 * beta]))
+        target_circuit.gates.append(Gate("Rx", [Qubit(1)], [2.0 * beta]))
+        return target_circuit.evaluate(symbols_map).to_unitary()
+
+    def test_set_cost_hamiltonian(self, ansatz):
+        # Given
+        new_cost_hamiltonian = QubitOperator((0, "Z")) - QubitOperator((1, "Z"))
+
+        # When
+        ansatz.cost_hamiltonian = new_cost_hamiltonian
+
+        # Then
+        assert ansatz._cost_hamiltonian == new_cost_hamiltonian
+
+    def test_set_cost_hamiltonian_invalidates_circuit(self, ansatz):
+        # Given
+        new_cost_hamiltonian = QubitOperator((0, "Z")) - QubitOperator((1, "Z"))
+
+        # When
+        ansatz.cost_hamiltonian = new_cost_hamiltonian
+
+        # Then
+        assert ansatz._parametrized_circuit is None
+
+    def test_set_mixer_hamiltonian(self, ansatz):
+        # Given
+        new_mixer_hamiltonian = QubitOperator((0, "Z")) - QubitOperator((1, "Z"))
+
+        # When
+        ansatz.mixer_hamiltonian = new_mixer_hamiltonian
+
+        # Then
+        ansatz._mixer_hamiltonian == new_mixer_hamiltonian
+
+    def test_set_mixer_hamiltonian_invalidates_circuit(self, ansatz):
+        # Given
+        new_mixer_hamiltonian = QubitOperator((0, "Z")) - QubitOperator((1, "Z"))
+
+        # When
+        ansatz.mixer_hamiltonian = new_mixer_hamiltonian
+
+        # Then
+        assert ansatz._parametrized_circuit is None
+
+    def test_get_number_of_qubits(self, ansatz):
+        # Given
+        new_cost_hamiltonian = (
+            QubitOperator((0, "Z")) + QubitOperator((1, "Z")) + QubitOperator((2, "Z"))
+        )
+        target_number_of_qubits = 3
+
+        # When
+        ansatz.cost_hamiltonian = new_cost_hamiltonian
+
+        # Then
+        assert ansatz.number_of_qubits == target_number_of_qubits
+
+    def test_get_number_of_qubits_with_ising_hamiltonian(self, ansatz):
+        # Given
+        new_cost_hamiltonian = (
+            QubitOperator((0, "Z")) + QubitOperator((1, "Z")) + QubitOperator((2, "Z"))
+        )
+        new_cost_hamiltonian = change_operator_type(new_cost_hamiltonian, IsingOperator)
+        target_number_of_qubits = 3
+
+        # When
+        ansatz.cost_hamiltonian = new_cost_hamiltonian
+
+        # Then
+        assert ansatz.number_of_qubits == target_number_of_qubits
+
+    def test_get_parametrizable_circuit(self, ansatz, beta, gamma):
+        # Then
+        assert ansatz.parametrized_circuit.symbolic_params == [
+            gamma,
+            beta,
+        ]
+
+    def test_generate_circuit(self, ansatz, symbols_map, target_unitary):
+        # When
+        parametrized_circuit = ansatz._generate_circuit()
+        evaluated_circuit = parametrized_circuit.evaluate(symbols_map)
+        final_unitary = evaluated_circuit.to_unitary()
+
+        # Then
+        assert compare_unitary(final_unitary, target_unitary, tol=1e-10)
+
+    def test_generate_circuit_with_ising_operator(
+        self, ansatz, symbols_map, target_unitary
+    ):
+        # When
+        ansatz.cost_hamiltonian = change_operator_type(
+            ansatz.cost_hamiltonian, IsingOperator
+        )
+
+        parametrized_circuit = ansatz._generate_circuit()
+        evaluated_circuit = parametrized_circuit.evaluate(symbols_map)
+        final_unitary = evaluated_circuit.to_unitary()
+
+        # Then
+        assert compare_unitary(final_unitary, target_unitary, tol=1e-10)
+

--- a/src/python/zquantum/qaoa/ansatzes/farhi2_test.py
+++ b/src/python/zquantum/qaoa/ansatzes/farhi2_test.py
@@ -15,14 +15,8 @@ import numpy as np
 import sympy
 
 
-def _make_ansatz():
-    cost_hamiltonian = QubitOperator((0, "Z")) + QubitOperator((1, "Z"))
-    mixer_hamiltonian = QubitOperator((0, "X")) + QubitOperator((1, "X"))
-    return QAOAFarhiAnsatz(
-        number_of_layers=1,
-        cost_hamiltonian=cost_hamiltonian,
-        mixer_hamiltonian=mixer_hamiltonian,
-    )
+# --------- contracts ---------
+# Imagine this section is defined in z-quantum-core
 
 
 def _validate_setting_number_of_layers(ansatz):
@@ -45,15 +39,15 @@ def _validate_set_number_of_layers_invalidates_parametrized_circuit(ansatz):
         return True
 
 
-# ----------- start
-
 def _validate_number_of_params_greater_than_0(ansatz):
     if ansatz.number_of_layers != 0:
         return ansatz.number_of_params >= 0
     return True
 
+
 def _validate_number_of_qubits_greater_than_0(ansatz):
     return ansatz.number_of_qubits > 0
+
 
 def _validate_get_executable_circuit_is_not_empty(ansatz):
     # Given
@@ -73,83 +67,39 @@ def _validate_get_executable_circuit_does_not_contain_symbols(ansatz):
     circuit = ansatz.get_executable_circuit(params=params)
 
     # Then
-    # for gate in circuit.gates:
-    #     return len(gate.symbolic_params) == 0
     return all(len(gate.symbolic_params) == 0 for gate in circuit.gates)
 
 
-ALL_CONTRACTS = [
+ANSATZ_CONTRACTS = [
     _validate_setting_number_of_layers,
+    _validate_set_number_of_layers_invalidates_parametrized_circuit,
+    _validate_number_of_params_greater_than_0,
     _validate_number_of_qubits_greater_than_0,
+    _validate_get_executable_circuit_is_not_empty,
+    _validate_get_executable_circuit_does_not_contain_symbols,
 ]
 
 
-# ^^^^ - z-quantum-core
-# below - z-quantum-qaoa
+# --------- /contracts ---------
 
 
-@pytest.mark.parametrize('contract', ALL_CONTRACTS)
-def test_ansatz_contract(self, contract):
+def _make_ansatz():
+    cost_hamiltonian = QubitOperator((0, "Z")) + QubitOperator((1, "Z"))
+    mixer_hamiltonian = QubitOperator((0, "X")) + QubitOperator((1, "X"))
+    return QAOAFarhiAnsatz(
+        number_of_layers=1,
+        cost_hamiltonian=cost_hamiltonian,
+        mixer_hamiltonian=mixer_hamiltonian,
+    )
+
+
+@pytest.mark.parametrize('contract', ANSATZ_CONTRACTS)
+def test_ansatz_contract(contract):
     ansatz = _make_ansatz()
     assert contract(ansatz)
 
-#     def test_set_number_of_layers(self, ansatz):
-#         assert _validate_setting_number_of_layers(ansatz)
 
-#         # # Given
-#         # new_number_of_layers = 100
-#         # # When
-#         # ansatz.number_of_layers = new_number_of_layers
-#         # # Then
-#         # assert ansatz.number_of_layers == new_number_of_layers
-
-#     def test_set_number_of_layers_invalidates_parametrized_circuit(self, ansatz):
-#         assert _validate_set_number_of_layers_invalidates_parametrized_circuit(ansatz)
-#         # # Given
-#         # new_number_of_layers = 100
-#         # if ansatz.supports_parametrized_circuits:
-#         #     initial_circuit = ansatz.parametrized_circuit
-
-#         #     # When
-#         #     ansatz.number_of_layers = new_number_of_layers
-
-#         #     # Then
-#         #     assert ansatz._parametrized_circuit is None
-
-#     # TODO: check with QCBM?
-#     def test_number_of_params_greater_than_0(self, ansatz):
-#         assert _validate_number_of_params_greater_than_0(ansatz)
-#         # if ansatz.number_of_layers != 0:
-#         #     assert ansatz.number_of_params >= 0
-
-#     def test_number_of_qubits_greater_than_0(self, ansatz):
-#         assert _validate_number_of_qubits_greater_than_0(ansatz)
-
-#     def test_get_executable_circuit_is_not_empty(self, ansatz):
-#         assert _validate_get_executable_circuit_is_not_empty(ansatz)
-#         # # Given
-#         # params = np.random.random([ansatz.number_of_params])
-
-#         # # When
-#         # circuit = ansatz.get_executable_circuit(params)
-
-#         # # Then
-#         # assert len(circuit.gates) > 0
-
-#     def test_get_executable_circuit_does_not_contain_symbols(self, ansatz):
-#         assert _validate_get_executable_circuit_does_not_contain_symbols(ansatz)
-#         # # Given
-#         # params = np.random.random([ansatz.number_of_params])
-
-#         # # When
-#         # circuit = ansatz.get_executable_circuit(params=params)
-
-#         # # Then
-#         # for gate in circuit.gates:
-#         #     assert len(gate.symbolic_params) == 0
-
-
-class TestFahriStandalone:
+class TestFahriAnsatz:
     @pytest.fixture
     def ansatz(self):
         return _make_ansatz()

--- a/src/python/zquantum/qaoa/ansatzes/farhi2_test.py
+++ b/src/python/zquantum/qaoa/ansatzes/farhi2_test.py
@@ -24,11 +24,120 @@ def _make_ansatz():
     )
 
 
-class TestFahriInherited(AnsatzTests):
+def _validate_setting_number_of_layers(ansatz):
+    new_number_of_layers = 100
+    ansatz.number_of_layers = new_number_of_layers
+    return ansatz.number_of_layers == new_number_of_layers
+
+
+def _validate_set_number_of_layers_invalidates_parametrized_circuit(ansatz):
+    new_number_of_layers = 100
+    if ansatz.supports_parametrized_circuits:
+        initial_circuit = ansatz.parametrized_circuit
+
+        # When
+        ansatz.number_of_layers = new_number_of_layers
+
+        # Then
+        return ansatz._parametrized_circuit is None
+    else:
+        return True
+
+
+# ----------- start
+
+def _validate_number_of_params_greater_than_0(ansatz):
+    if ansatz.number_of_layers != 0:
+        return ansatz.number_of_params >= 0
+    return True
+
+def _validate_number_of_qubits_greater_than_0(ansatz):
+    return ansatz.number_of_qubits > 0
+
+def _validate_get_executable_circuit_is_not_empty(ansatz):
+    # Given
+    params = np.random.random([ansatz.number_of_params])
+
+    # When
+    circuit = ansatz.get_executable_circuit(params)
+
+    # Then
+    return len(circuit.gates) > 0
+
+def _validate_get_executable_circuit_does_not_contain_symbols(ansatz):
+    # Given
+    params = np.random.random([ansatz.number_of_params])
+
+    # When
+    circuit = ansatz.get_executable_circuit(params=params)
+
+    # Then
+    # for gate in circuit.gates:
+    #     return len(gate.symbolic_params) == 0
+    return all(len(gate.symbolic_params) == 0 for gate in circuit.gates)
+
+# ----------- start
+
+class TestFahriInherited:
     @pytest.fixture
     def ansatz(self):
         """Plugs-in into AnsatzTests test cases."""
         return _make_ansatz()
+
+    def test_set_number_of_layers(self, ansatz):
+        assert _validate_setting_number_of_layers(ansatz)
+
+        # # Given
+        # new_number_of_layers = 100
+        # # When
+        # ansatz.number_of_layers = new_number_of_layers
+        # # Then
+        # assert ansatz.number_of_layers == new_number_of_layers
+
+    def test_set_number_of_layers_invalidates_parametrized_circuit(self, ansatz):
+        assert _validate_set_number_of_layers_invalidates_parametrized_circuit(ansatz)
+        # # Given
+        # new_number_of_layers = 100
+        # if ansatz.supports_parametrized_circuits:
+        #     initial_circuit = ansatz.parametrized_circuit
+
+        #     # When
+        #     ansatz.number_of_layers = new_number_of_layers
+
+        #     # Then
+        #     assert ansatz._parametrized_circuit is None
+
+    # TODO: check with QCBM?
+    def test_number_of_params_greater_than_0(self, ansatz):
+        assert _validate_number_of_params_greater_than_0(ansatz)
+        # if ansatz.number_of_layers != 0:
+        #     assert ansatz.number_of_params >= 0
+
+    def test_number_of_qubits_greater_than_0(self, ansatz):
+        assert _validate_number_of_qubits_greater_than_0(ansatz)
+
+    def test_get_executable_circuit_is_not_empty(self, ansatz):
+        assert _validate_get_executable_circuit_is_not_empty(ansatz)
+        # # Given
+        # params = np.random.random([ansatz.number_of_params])
+
+        # # When
+        # circuit = ansatz.get_executable_circuit(params)
+
+        # # Then
+        # assert len(circuit.gates) > 0
+
+    def test_get_executable_circuit_does_not_contain_symbols(self, ansatz):
+        assert _validate_get_executable_circuit_does_not_contain_symbols(ansatz)
+        # # Given
+        # params = np.random.random([ansatz.number_of_params])
+
+        # # When
+        # circuit = ansatz.get_executable_circuit(params=params)
+
+        # # Then
+        # for gate in circuit.gates:
+        #     assert len(gate.symbolic_params) == 0
 
 
 class TestFahriStandalone:


### PR DESCRIPTION
This PR contains a PoC of my proposal for improved test sharing cases between projects. Thanks @mstechly for help in figuring this out!

Case study:
- `zquantum.core.interfaces.ansatz` defines how an ansatz should behave
- 3rd-party libraries implement ansatzes on their own, like `QAOAFarhiAnsatz` in this repo
- we want to provide a mechanism for easy checking if a 3rd-party class implemented the interface like we intended them to

Previously (see [fahri_ansatz_test](https://github.com/zapatacomputing/z-quantum-qaoa/blob/8df9876f31a6cd8962c8f3499a1d81896dd3fcf9/src/python/zquantum/qaoa/ansatzes/farhi_ansatz_test.py)), we've been defining pytest-compatible `TestFoo` classes in z-quantum-core and derived projects like this one created a subclass that inherited test case methods from `TestFoo`, additionally providing their own fixtures. I don't like that for a number of reasons, mostly there's a lot of implicit logic happening and it was hard to wrap head my head around all plugging-in, shadowing, inheriting, etc.

I'm proposing here a somewhat orthogonal approach:
1. Let's define the contracts for implementation of interfaces explicitly, in form of validator functions, bundled with z-quantum-core, unrelated to `pytest`.
2. Such functions would take an ansatz object and validate a given property, either raising an exception or returning `False` (we could agree on one style for validators).
3. On the client library side (like this repo), we simply create a single parametrized test (see `test_ansatz_contract`) that just executes the contract from z-quantum-core on object implemented in this repo.

This approach is explicit, no inheritance nor fixture magic is happening. It also removes the problem of convoluted test cases that _are_ executable in z-quantum-core with test cases that _aren't_ executed, but need to be bundled with the library.

This approach doesn't harm the test case visibility. The snippet blow shows a scenario where a single contract didn't pass. Note that `pytest` is smart enough to split parametrized test into separate test cases and print the executed contract name for the case that failed.
```
pytest src/python/zquantum/qaoa/ansatzes/farhi2_test.py --disable-warnings -k test_ansatz_contract
====================================== test session starts =======================================
platform darwin -- Python 3.7.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/alex/Code/zapata/z-quantum-qaoa/src
collected 15 items / 9 deselected / 6 selected

src/python/zquantum/qaoa/ansatzes/farhi2_test.py ....F.                                    [100%]

============================================ FAILURES ============================================
______________ test_ansatz_contract[_validate_get_executable_circuit_is_not_empty] _______________

contract = <function _validate_get_executable_circuit_is_not_empty at 0x13769a830>

    @pytest.mark.parametrize('contract', ANSATZ_CONTRACTS)
    def test_ansatz_contract(contract):
        ansatz = _make_ansatz()
>       assert contract(ansatz)
E       assert False
E        +  where False = <function _validate_get_executable_circuit_is_not_empty at 0x13769a830>(<qaoa.ansatzes.farhi_ansatz.QAOAFarhiAnsatz object at 0x13770ca50>)

src/python/zquantum/qaoa/ansatzes/farhi2_test.py:99: AssertionError
==================================== short test summary info =====================================
FAILED src/python/zquantum/qaoa/ansatzes/farhi2_test.py::test_ansatz_contract[_validate_get_executable_circuit_is_not_empty]
===================== 1 failed, 5 passed, 9 deselected, 3 warnings in 3.55s ======================
```