### PR TITLE
Fix using obsolete graph generator argument

### DIFF
--- a/examples/maxcut-qaoa-lbl.j2
+++ b/examples/maxcut-qaoa-lbl.j2
@@ -51,8 +51,6 @@ steps:
     type: int
   - edge_probability: 0.8
     type: float
-  - random_weights: False
-    type: bool
   outputs:
   - name: graph
     type: graph

--- a/examples/maxcut-qaoa.yaml
+++ b/examples/maxcut-qaoa.yaml
@@ -167,8 +167,9 @@ steps:
   - optimizer_specs:
       module_name: zquantum.optimizers.grid_search
       function_name: GridSearchOptimizer
-      options: {"keep_value_history": true}
     type: specs
+  - keep_history: True
+    type: bool
   - cost_function_specs:
       module_name: zquantum.core.cost_function
       function_name: AnsatzBasedCostFunction

--- a/examples/maxcut-qaoa.yaml
+++ b/examples/maxcut-qaoa.yaml
@@ -44,8 +44,6 @@ steps:
     type: int
   - edge_probability: 0.8
     type: float
-  - random_weights: False
-    type: bool
   outputs:
   - name: graph
     type: graph

--- a/examples/maxcut-qaoa.yaml
+++ b/examples/maxcut-qaoa.yaml
@@ -44,6 +44,12 @@ steps:
     type: int
   - edge_probability: 0.8
     type: float
+  - sampler_specs:
+      module_name: zquantum.core.graph
+      function_name: uniform_sampler
+      min_value: 2
+      max_value: 10
+    type: specs
   outputs:
   - name: graph
     type: graph

--- a/examples/warm-start-qaoa.yaml
+++ b/examples/warm-start-qaoa.yaml
@@ -45,8 +45,6 @@ steps:
     type: int
   - edge_probability: 0.8
     type: float
-  - random_weights: False
-    type: bool
   outputs:
   - name: graph
     type: graph


### PR DESCRIPTION
We changed arguments to graph step functions in https://github.com/zapatacomputing/z-quantum-core/pull/362. This PR changes the examples so that they use the default argument values. This shouldn't change the functionality.