### PR TITLE
Make CVaR work with exact expectation values

### DIFF
--- a/src/python/zquantum/qaoa/estimators/_cvar_estimator.py
+++ b/src/python/zquantum/qaoa/estimators/_cvar_estimator.py
@@ -1,6 +1,7 @@
 import numpy as np
 from openfermion import IsingOperator
-from typing import List
+from typing import Dict, List, Optional
+from pyquil.wavefunction import Wavefunction
 
 from zquantum.core.interfaces.backend import QuantumBackend
 from zquantum.core.measurement import ExpectationValues, Measurements
@@ -9,6 +10,7 @@ from zquantum.core.interfaces.estimation import (
     EstimateExpectationValues,
     EstimationTask,
 )
+from zquantum.core.utils import dec2bin
 
 
 class CvarEstimator(EstimateExpectationValues):
@@ -27,7 +29,10 @@ class CvarEstimator(EstimateExpectationValues):
         self.alpha = alpha
 
     def __call__(
-        self, backend: QuantumBackend, estimation_tasks: List[EstimationTask]
+        self,
+        backend: QuantumBackend,
+        estimation_tasks: List[EstimationTask],
+        use_exact_expectation_values: Optional[bool] = False,
     ) -> List[ExpectationValues]:
         """Given a circuit, backend, and target operators, this method produces expectation values
         using CVaR method.
@@ -36,6 +41,8 @@ class CvarEstimator(EstimateExpectationValues):
             backend: the backend that will be used to run the circuits
             estimation_tasks: the estimation tasks defining the problem. Each task consist of target operator, circuit and number of shots.
             alpha: defines what part of the measurements should be taken into account in the estimation process.
+            use_exact_expectation_values: whether to calculate expectation values by using exact wavefunctions or by taking samples.
+                (If true, the number of shots in each estimation task will be disregarded.)
         """
         if self.alpha > 1 or self.alpha <= 0:
             raise ValueError("alpha needs to be a value between 0 and 1.")
@@ -43,23 +50,43 @@ class CvarEstimator(EstimateExpectationValues):
         circuits, operators, shots_per_circuit = zip(
             *[(e.circuit, e.operator, e.number_of_shots) for e in estimation_tasks]
         )
-        distributions_list = [
-            backend.get_bitstring_distribution(circuit, n_samples=n_shots)
-            for circuit, n_shots in zip(circuits, shots_per_circuit)
-        ]
 
-        return [
-            ExpectationValues(
-                np.array(
-                    [
-                        _calculate_expectation_value_for_distribution(
-                            distribution, operator, self.alpha
-                        )
-                    ]
+        if not use_exact_expectation_values:
+            distributions_list = [
+                backend.get_bitstring_distribution(circuit, n_samples=n_shots)
+                for circuit, n_shots in zip(circuits, shots_per_circuit)
+            ]
+
+            return [
+                ExpectationValues(
+                    np.array(
+                        [
+                            _calculate_expectation_value_for_distribution(
+                                distribution, operator, self.alpha
+                            )
+                        ]
+                    )
                 )
-            )
-            for distribution, operator in zip(distributions_list, operators)
-        ]
+                for distribution, operator in zip(distributions_list, operators)
+            ]
+
+        else:
+            wavefunctions_list = [
+                backend.get_wavefunction(circuit) for circuit in circuits
+            ]
+
+            return [
+                ExpectationValues(
+                    np.array(
+                        [
+                            _calculate_expectation_value_for_wavefunction(
+                                distribution, operator, self.alpha
+                            )
+                        ]
+                    )
+                )
+                for distribution, operator in zip(wavefunctions_list, operators)
+            ]
 
 
 def _calculate_expectation_value_for_distribution(
@@ -68,11 +95,55 @@ def _calculate_expectation_value_for_distribution(
     # Calculates expectation value per bitstring
     expectation_values_per_bitstring = {}
     for bitstring in distribution.distribution_dict:
-        expected_value = Measurements([bitstring]).get_expectation_values(
-            operator, use_bessel_correction=False
-        )
-        expectation_values_per_bitstring[bitstring] = np.sum(expected_value.values)
+        expected_value = _calculate_expectation_value_of_bitstring(bitstring, operator)
+        expectation_values_per_bitstring[bitstring] = expected_value
 
+    return _sum_expectation_values(
+        expectation_values_per_bitstring, distribution.distribution_dict, alpha
+    )
+
+
+def _calculate_expectation_value_for_wavefunction(
+    wavefunction: Wavefunction, operator: IsingOperator, alpha: float
+) -> float:
+    expectation_values_per_bitstring = {}
+    probability_per_bitstring = {}
+
+    n_qubits = wavefunction.amplitudes.shape[0].bit_length() - 1
+
+    for decimal_bitstring in range(2 ** n_qubits):
+        # `decimal_bitstring` is the bitstring converted to decimal.
+
+        # Convert decimal bitstring into bitstring
+        bitstring = "".join([str(int) for int in dec2bin(decimal_bitstring, n_qubits)])
+
+        # Calculate expectation values for each bitstring.
+        expected_value = _calculate_expectation_value_of_bitstring(bitstring, operator)
+        expectation_values_per_bitstring[bitstring] = expected_value
+
+        # Compute the probability p(x) for each n-bitstring x from the wavefunction,
+        # p(x) = |amplitude of x| ^ 2.
+        probability = np.abs(wavefunction.amplitudes[decimal_bitstring]) ** 2
+        probability_per_bitstring[bitstring] = float(probability)
+
+    return _sum_expectation_values(
+        expectation_values_per_bitstring, probability_per_bitstring, alpha
+    )
+
+
+def _sum_expectation_values(
+    expectation_values_per_bitstring: Dict[str, float],
+    probability_per_bitstring: Dict[str, float],
+    alpha: float,
+) -> float:
+    """Returns the cumulative sum of expectation values until the cumulative probability of bitstrings
+    s_k = p(x_1) + … + p(x_k) >= alpha
+
+    Args:
+        expectation_values_per_bitstring: dictionary of bitstrings and their corresponding expectation values.
+        probability_per_bitstring: dictionary of bitstrings and their corresponding expectation probabilities.
+        alpha: see description in the `__call__()` method.
+    """
     # Sorts expectation values by values.
     sorted_expectation_values_per_bitstring_list = sorted(
         expectation_values_per_bitstring.items(), key=lambda item: item[1]
@@ -84,7 +155,7 @@ def _calculate_expectation_value_for_distribution(
     # When the cumulative probability associated with these bitstrings is higher than alpha,
     # it stops and effectively discards all the remaining values.
     for bitstring, expectation_value in sorted_expectation_values_per_bitstring_list:
-        prob = distribution.distribution_dict[bitstring]
+        prob = probability_per_bitstring[bitstring]
         if cumulative_prob + prob < alpha:
             cumulative_prob += prob
             cumulative_value += prob * expectation_value
@@ -93,3 +164,11 @@ def _calculate_expectation_value_for_distribution(
             break
     final_value = cumulative_value / alpha
     return final_value
+
+
+def _calculate_expectation_value_of_bitstring(bitstring: str, operator: IsingOperator):
+    """Calculate expectation value for a bitstring based on an operator."""
+    expected_value = Measurements([bitstring]).get_expectation_values(
+        operator, use_bessel_correction=False
+    )
+    return np.sum(expected_value.values)

--- a/src/python/zquantum/qaoa/estimators/_cvar_estimator.py
+++ b/src/python/zquantum/qaoa/estimators/_cvar_estimator.py
@@ -14,25 +14,31 @@ from zquantum.core.utils import dec2bin
 
 
 class CvarEstimator(EstimateExpectationValues):
-    """An estimator for calculating expectation value using CVaR method.
-    The main idea is that for diagonal operators the ground state of the Hamiltonian is a base state.
-    In particular for the combinatorial optimization problems, we often care only about getting a single bitstring representing the solution.
-    Therefore, it might be beneficial for the optimization process to discard samples that represent inferior solutions.
-    CVaR Estimator takes uses only a top X percentile of the samples for calculating the expectation value, where X = alpha*100.
+    def __init__(
+        self, alpha: float, use_exact_expectation_values: Optional[bool] = False
+    ) -> None:
+        """An estimator for calculating expectation value using CVaR method.
+        The main idea is that for diagonal operators the ground state of the Hamiltonian is a base state.
+        In particular for the combinatorial optimization problems, we often care only about getting a single bitstring representing the solution.
+        Therefore, it might be beneficial for the optimization process to discard samples that represent inferior solutions.
+        CVaR Estimator takes uses only a top X percentile of the samples for calculating the expectation value, where X = alpha*100.
 
-    Reference: https://arxiv.org/abs/1907.04769
-    "Improving Variational Quantum Optimization using CVaR", P. Barkoutsos, G. Nannicini, A. Robert, I. Tavernelli, and S. Woerner
-    """
+        Reference: https://arxiv.org/abs/1907.04769
+        "Improving Variational Quantum Optimization using CVaR", P. Barkoutsos, G. Nannicini, A. Robert, I. Tavernelli, and S. Woerner
 
-    def __init__(self, alpha: float) -> None:
+        Args:
+            alpha: defines what part of the measurements should be taken into account in the estimation process.
+            use_exact_expectation_values: whether to calculate expectation values by using exact wavefunctions or by taking samples.
+                (If True, the number of shots in each estimation task will be disregarded.)
+        """
         super().__init__()
         self.alpha = alpha
+        self.use_exact_expectation_values = use_exact_expectation_values
 
     def __call__(
         self,
         backend: QuantumBackend,
         estimation_tasks: List[EstimationTask],
-        use_exact_expectation_values: Optional[bool] = False,
     ) -> List[ExpectationValues]:
         """Given a circuit, backend, and target operators, this method produces expectation values
         using CVaR method.
@@ -40,9 +46,6 @@ class CvarEstimator(EstimateExpectationValues):
         Args:
             backend: the backend that will be used to run the circuits
             estimation_tasks: the estimation tasks defining the problem. Each task consist of target operator, circuit and number of shots.
-            alpha: defines what part of the measurements should be taken into account in the estimation process.
-            use_exact_expectation_values: whether to calculate expectation values by using exact wavefunctions or by taking samples.
-                (If true, the number of shots in each estimation task will be disregarded.)
         """
         if self.alpha > 1 or self.alpha <= 0:
             raise ValueError("alpha needs to be a value between 0 and 1.")
@@ -51,7 +54,7 @@ class CvarEstimator(EstimateExpectationValues):
             *[(e.circuit, e.operator, e.number_of_shots) for e in estimation_tasks]
         )
 
-        if not use_exact_expectation_values:
+        if not self.use_exact_expectation_values:
             distributions_list = [
                 backend.get_bitstring_distribution(circuit, n_samples=n_shots)
                 for circuit, n_shots in zip(circuits, shots_per_circuit)
@@ -166,7 +169,9 @@ def _sum_expectation_values(
     return final_value
 
 
-def _calculate_expectation_value_of_bitstring(bitstring: str, operator: IsingOperator):
+def _calculate_expectation_value_of_bitstring(
+    bitstring: str, operator: IsingOperator
+) -> float:
     """Calculate expectation value for a bitstring based on an operator."""
     expected_value = Measurements([bitstring]).get_expectation_values(
         operator, use_bessel_correction=False

--- a/src/python/zquantum/qaoa/estimators/_cvar_estimator.py
+++ b/src/python/zquantum/qaoa/estimators/_cvar_estimator.py
@@ -36,9 +36,7 @@ class CvarEstimator(EstimateExpectationValues):
         self.use_exact_expectation_values = use_exact_expectation_values
 
     def __call__(
-        self,
-        backend: QuantumBackend,
-        estimation_tasks: List[EstimationTask],
+        self, backend: QuantumBackend, estimation_tasks: List[EstimationTask]
     ) -> List[ExpectationValues]:
         """Given a circuit, backend, and target operators, this method produces expectation values
         using CVaR method.

--- a/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
+++ b/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
@@ -9,7 +9,8 @@ from zquantum.core.measurement import Measurements
 from zquantum.qaoa.estimators import CvarEstimator
 
 from zquantum.core.interfaces.estimation import EstimationTask
-from qequlacs.simulator import QulacsSimulator
+from pyquil.wavefunction import Wavefunction
+import numpy as np
 
 
 class TestCvarEstimator:
@@ -37,7 +38,11 @@ class TestCvarEstimator:
             bitstrings = [("0"), ("1")]
             return Measurements(bitstrings)
 
+        def custom_get_wavefunction(circuit):
+            return Wavefunction(np.array([np.sqrt(0.5) + 0j, np.sqrt(0.5) + 0j]))
+
         backend.run_circuit_and_measure = custom_run_circuit_and_measure
+        backend.get_wavefunction = custom_get_wavefunction
         return backend
 
     def test_raises_exception_if_operator_is_not_ising(
@@ -90,7 +95,7 @@ class TestCvarEstimator:
         assert expectation_values[0].values == pytest.approx(target_value)
 
     def test_cvar_estimator_returns_correct_values_without_sampling(
-        self, estimator, operator
+        self, estimator, backend, operator
     ):
         # Given
         estimation_tasks = [
@@ -103,7 +108,7 @@ class TestCvarEstimator:
 
         # When
         expectation_values = estimator(
-            backend=QulacsSimulator(),
+            backend=backend,
             estimation_tasks=estimation_tasks,
             use_exact_expectation_values=True,
         )

--- a/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
+++ b/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
@@ -34,14 +34,10 @@ class TestCvarEstimator:
     def backend(self, request):
         backend = MockQuantumBackend()
 
-        def custom_run_circuit_and_measure(circuit, n_samples):
-            bitstrings = [("0"), ("1")]
-            return Measurements(bitstrings)
-
         def custom_get_wavefunction(circuit):
+            assert circuit == Circuit([H(0)])
             return Wavefunction(np.array([np.sqrt(0.5) + 0j, np.sqrt(0.5) + 0j]))
 
-        backend.run_circuit_and_measure = custom_run_circuit_and_measure
         backend.get_wavefunction = custom_get_wavefunction
         return backend
 
@@ -78,7 +74,7 @@ class TestCvarEstimator:
 
     def test_cvar_estimator_returns_correct_values(self, estimator, backend, operator):
         # Given
-        estimation_tasks = [EstimationTask(operator, Circuit([H(0)]), 10)]
+        estimation_tasks = [EstimationTask(operator, Circuit([H(0)]), 10000)]
         if estimator.alpha <= 0.5:
             target_value = -1
         else:
@@ -92,7 +88,7 @@ class TestCvarEstimator:
 
         # Then
         assert len(expectation_values) == len(estimation_tasks)
-        assert expectation_values[0].values == pytest.approx(target_value)
+        assert expectation_values[0].values == pytest.approx(target_value, abs=2e-2)
 
     def test_cvar_estimator_returns_correct_values_without_sampling(
         self, estimator, backend, operator

--- a/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
+++ b/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
@@ -9,6 +9,7 @@ from zquantum.core.measurement import Measurements
 from zquantum.qaoa.estimators import CvarEstimator
 
 from zquantum.core.interfaces.estimation import EstimationTask
+from qequlacs.simulator import QulacsSimulator
 
 
 class TestCvarEstimator:
@@ -82,6 +83,29 @@ class TestCvarEstimator:
         expectation_values = estimator(
             backend=backend,
             estimation_tasks=estimation_tasks,
+        )
+
+        # Then
+        assert len(expectation_values) == len(estimation_tasks)
+        assert expectation_values[0].values == pytest.approx(target_value)
+
+    def test_cvar_estimator_returns_correct_values_without_sampling(
+        self, estimator, operator
+    ):
+        # Given
+        estimation_tasks = [
+            EstimationTask(operator, Circuit([H(0)]), number_of_shots=None)
+        ]
+        if estimator.alpha <= 0.5:
+            target_value = -1
+        else:
+            target_value = (-1 * 0.5 + 1 * (estimator.alpha - 0.5)) / estimator.alpha
+
+        # When
+        expectation_values = estimator(
+            backend=QulacsSimulator(),
+            estimation_tasks=estimation_tasks,
+            use_exact_expectation_values=True,
         )
 
         # Then

--- a/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
+++ b/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
@@ -25,19 +25,19 @@ class TestCvarEstimator:
                 "use_exact_expectation_values": True,
             },
             {
-                "alpha": 0.5,
+                "alpha": 0.8,
                 "use_exact_expectation_values": False,
             },
             {
-                "alpha": 0.5,
+                "alpha": 0.8,
                 "use_exact_expectation_values": True,
             },
             {
-                "alpha": 0.8,
+                "alpha": 1.0,
                 "use_exact_expectation_values": False,
             },
             {
-                "alpha": 0.8,
+                "alpha": 1.0,
                 "use_exact_expectation_values": True,
             },
         ]

--- a/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
+++ b/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
@@ -1,16 +1,11 @@
 import pytest
 from openfermion import QubitOperator, IsingOperator
 
-from zquantum.core.interfaces.mock_objects import (
-    MockQuantumBackend,
-)
+from zquantum.core.symbolic_simulator import SymbolicSimulator
 from zquantum.core.circuits import Circuit, X, H
-from zquantum.core.measurement import Measurements
 from zquantum.qaoa.estimators import CvarEstimator
 
 from zquantum.core.interfaces.estimation import EstimationTask
-from pyquil.wavefunction import Wavefunction
-import numpy as np
 
 
 class TestCvarEstimator:
@@ -58,15 +53,8 @@ class TestCvarEstimator:
         return [EstimationTask(operator, circuit, 10)]
 
     @pytest.fixture()
-    def backend(self, request):
-        backend = MockQuantumBackend()
-
-        def custom_get_wavefunction(circuit):
-            # Returns wavefunction for circuit == Circuit([H(0)])
-            return Wavefunction(np.array([np.sqrt(0.5) + 0j, np.sqrt(0.5) + 0j]))
-
-        backend.get_wavefunction = custom_get_wavefunction
-        return backend
+    def backend(self):
+        return SymbolicSimulator()
 
     def test_raises_exception_if_operator_is_not_ising(
         self, estimator, backend, circuit

--- a/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
+++ b/tests/zquantum/qaoa/estimators/cvar_estimator_test.py
@@ -115,4 +115,4 @@ class TestCvarEstimator:
 
         # Then
         assert len(expectation_values) == len(estimation_tasks)
-        assert expectation_values[0].values == pytest.approx(target_value, abs=2e-2)
+        assert expectation_values[0].values == pytest.approx(target_value, abs=2e-1)


### PR DESCRIPTION
From Jira: Guoming suggested that CVaR could actually work without the need for sampling, which should be faster.

Here's his explanation:

You first compute the probability p(x) for each n-bitstring x  from the wavefunction, i.e. p(x)=|amplitude of x|^2. Then sort all the n-bitstrings according to their energies, say, x_1,x_2,... such that E(x_1)<= E(x_2) <= …. Then compute the cumulative sum of the probability s_k = p(x_1) + … + p(x_k) until s_k >= alpha. Then compute the conditioned mean value of E(x_j) for 1<=j<=k , where x_j has probability p(x_j) for j<k and alpha-s_{k-1} for j=k . This value is the limit of CVaR for a large number of samples.